### PR TITLE
fixed to use the real optparser module

### DIFF
--- a/examples/express/app.coffee
+++ b/examples/express/app.coffee
@@ -1,4 +1,5 @@
 app = require('express').createServer()
+sys = require('sys')
 
 app.register '.coffee', require('coffeekup')
 app.set 'view engine', 'coffee'
@@ -15,4 +16,4 @@ app.get '/inline', (req, res) ->
 
 app.listen 3000
 
-puts "Listening on 3000..."
+sys.puts "Listening on 3000..."

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('coffee-script')
+module.exports = require('./lib/coffeekup')

--- a/lib/coffeekup.coffee
+++ b/lib/coffeekup.coffee
@@ -121,6 +121,16 @@ tags = 'a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|b
 
 coffeekup.compile = (template, options = {}) ->
   options.locals ?= {}
+
+  # Shim for express.
+  if options.locals.body?
+    options.context.body = options.locals.body
+    delete options.locals.body
+
+  if options.body?
+    options.context.body = options.body
+    delete options.body
+
   
   if typeof template is 'function' then template = String(template)
   else if typeof template is 'string' and coffee?
@@ -148,16 +158,11 @@ coffeekup.compile = (template, options = {}) ->
   new Function('ck_options', code)
 
 cache = {}
-
 coffeekup.render = (template, options = {}) ->
   options.context ?= {}
   options.locals ?= {}
   options.cache ?= on
 
-  # Shim for express.
-  if options.locals.body?
-    options.context.body = options.locals.body
-    delete options.locals.body
 
   if options.cache and cache[template]? then tpl = cache[template]
   else if options.cache then tpl = cache[template] = coffeekup.compile(template, options)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./coffeekup')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {"coffee-script": ">= 1.0.0"},
   "keywords": ["template", "view", "coffeescript"],
   "bin": {"coffeekup": "./bin/coffeekup.coffee"},
+  "main": "./lib/index.js",
   "directories": {"lib": "./lib"},
   "engines": {"node": ">= 0.2.6"}
 }


### PR DESCRIPTION
instead of sneaking into the private version in coffee-script that no longer exists, this uses the official optparser module directly.

also a few npm changes i merged in form other forks. 
