### PR TITLE
Coffeescript-tag support for 'src' attribute

### DIFF
--- a/lib/coffeekup.coffee
+++ b/lib/coffeekup.coffee
@@ -91,8 +91,13 @@ skeleton = (ck_options = {}) ->
   
     null
   
-  coffeescript = (code) ->
-    script ";(#{code})();"
+  coffeescript = ->
+    switch typeof arguments[0]
+      when 'object'
+        arguments[0].type = "text/coffeescript"
+        script arguments[0]
+      when 'function'
+        script type: "text/javascript", ";(#{arguments[0]})();"
 
   null
 

--- a/test.coffee
+++ b/test.coffee
@@ -45,7 +45,7 @@ exports.run = ->
 
   test 'CoffeeScript', ->
     """
-      <script>;(function () {
+      <script type="text/javascript">;(function () {
                 return $(document).ready(function() {
                   return alert('hi!');
                 });
@@ -53,6 +53,10 @@ exports.run = ->
       coffeescript ->
         $(document).ready ->
           alert 'hi!'
+
+  test 'CoffeeScript src-attr', ->
+    """<script src="script.coffee" type="text/coffeescript"></script>""" is render ->
+      coffeescript src: 'script.coffee'
 
   test 'Context vars', ->
     '<h1>bar</h1>' is render (-> h1 @foo), context: {foo: 'bar'}

--- a/test.coffee
+++ b/test.coffee
@@ -105,7 +105,7 @@ exports.run = ->
 
 puts = console.log
 print = require('sys').print
-ck = require 'coffeekup'
+ck = require './lib/coffeekup'
 render = ck.render
 
 [tests, passed, failed, errors] = [[], [], [], []]


### PR DESCRIPTION
These changes allow for the following syntax in addition to the present:
    coffeescript src: "script.coffee"
    # <script type="text/coffeescript" src="script.coffee"></script>

It also introduces the change that all normal use of `coffeescript` will include the `type` attribute.
A fix is also included that changes the tests to use the version of Coffeekup build using `make build`.
