### PR TITLE
npm v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 material/
 lib/coffeekup.js
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./coffeekup')
+module.exports = require('./lib/coffeekup')


### PR DESCRIPTION
I'm hoping we can get this pulled soon.  It's affecting zappa too.  The 0.3 npm has some issues https://groups.google.com/forum/#!topic/duostack-beta/KjhwgoV7a3M with tar.gz packages, so a workaround (for duostack) doesn't seem possible...  The package has to be published in order to work at all.
