### PR TITLE
Okay, here's a fresh new clone that has nested objects and express helpers

### DIFF
--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -140,15 +140,20 @@ skeleton = (data = {}) ->
           text c
         text '"'
 
-    render_attrs: (obj) ->
+    render_attrs: (obj, prefix = '') ->
       for k, v of obj
         # true is rendered as `selected="selected"`.
         if typeof v is 'boolean' and v
           v = k
+        
+        if typeof v is 'object'
+          # if you have a lot of data attributes, it gets repetitive to keep typing 'data-'
+          # plus, it looks really good to group them together, e.g. data: { icon: 'gear', iconpos: 'right' }
+          @render_attrs(v, prefix + k + '-')
         # undefined, false and null result in the attribute not being rendered.
-        if v
+        else if v
           # strings, numbers, objects, arrays and functions are rendered "as is".
-          text " #{k}=\"#{@esc(v)}\""
+          text " #{prefix + k}=\"#{@esc(v)}\""
 
     render_contents: (contents) ->
       switch typeof contents


### PR DESCRIPTION
Helpers are, in other express view engines, locals.  So I expected app.helpers() and app.dynamicHelpers() to be available in coffeekup.  Instead, coffeekup used only its own `locals` and `hardcoded` mechanism.  This automatically loads helpers into `hardcoded`, and dynamicViewHelpers into `locals`

``` coffeescript
app.helpers
  sheet: (sheet)->
    link
      href: sheet
      rel: 'stylesheet'
      type: 'text/css'
```

``` coffeescript
head ->
  sheet '/css/styles.css'
```

The other feature this brings in is the ability to group `data` attributes (or others, I suppose, but I can't think of any).

``` coffeescript
a href:'/login', data: {icon:'arrow-r', iconpos:'right'}, 'Login'
```

``` html
<a href="/login" data-icon="arrow-r" data-iconpos="right">Login</a>
```
