### PR TITLE
Optimize compiled templates

### DIFF
--- a/benchmark.coffee
+++ b/benchmark.coffee
@@ -65,6 +65,8 @@ coffeekup_string_template = """
 
 coffeekup_compiled_template = coffeekup.compile coffeekup_template
 
+coffeekup_optimized_template = coffeekup.compile coffeekup_template, optimize: yes
+
 jade_template = '''
   !!! 5
   html(lang="en")
@@ -189,6 +191,7 @@ benchmark = (title, code) ->
 
 
 benchmark 'CoffeeKup (precompiled)', -> coffeekup_compiled_template data
+benchmark 'CoffeeKup (precompiled, optimized)', -> coffeekup_optimized_template data
 benchmark 'Jade (precompiled)', -> jade_compiled_template data
 benchmark 'haml-js (precompiled)', -> haml_template_compiled data
 benchmark 'Eco', -> eco.render eco_template, data

--- a/benchmark.coffee
+++ b/benchmark.coffee
@@ -1,3 +1,5 @@
+#!/usr/bin/env coffee
+
 coffeekup = require './src/coffeekup'
 jade = require 'jade'
 ejs = require 'ejs'
@@ -185,23 +187,23 @@ benchmark = (title, code) ->
     code()
   log "#{title}: #{new Date - start} ms"
 
-@run = ->
-  benchmark 'CoffeeKup (precompiled)', -> coffeekup_compiled_template data
-  benchmark 'Jade (precompiled)', -> jade_compiled_template data
-  benchmark 'haml-js (precompiled)', -> haml_template_compiled data
-  benchmark 'Eco', -> eco.render eco_template, data
 
-  console.log '\n'
+benchmark 'CoffeeKup (precompiled)', -> coffeekup_compiled_template data
+benchmark 'Jade (precompiled)', -> jade_compiled_template data
+benchmark 'haml-js (precompiled)', -> haml_template_compiled data
+benchmark 'Eco', -> eco.render eco_template, data
 
-  benchmark 'CoffeeKup (function, cache on)', -> coffeekup.render coffeekup_template, data, cache: on
-  benchmark 'CoffeeKup (string, cache on)', -> coffeekup.render coffeekup_string_template, data, cache: on
-  benchmark 'Jade (cache on)', -> jade.render jade_template, locals: data, cache: on, filename: 'test'
-  benchmark 'ejs (cache on)', -> ejs.render ejs_template, locals: data, cache: on, filename: 'test'
+console.log '\n'
 
-  console.log '\n'
+benchmark 'CoffeeKup (function, cache on)', -> coffeekup.render coffeekup_template, data, cache: on
+benchmark 'CoffeeKup (string, cache on)', -> coffeekup.render coffeekup_string_template, data, cache: on
+#benchmark 'Jade (cache on)', -> jade.render jade_template, locals: data, cache: on, filename: 'test'
+benchmark 'ejs (cache on)', -> ejs.render ejs_template, locals: data, cache: on, filename: 'test'
 
-  benchmark 'CoffeeKup (function, cache off)', -> coffeekup.render coffeekup_template, data
-  benchmark 'CoffeeKup (string, cache off)', -> coffeekup.render coffeekup_string_template, data, cache: off
-  benchmark 'Jade (cache off)', -> jade.render jade_template, locals: data
-  benchmark 'haml-js', -> haml.render haml_template, locals: data
-  benchmark 'ejs (cache off)', -> ejs.render ejs_template, locals: data
+console.log '\n'
+
+benchmark 'CoffeeKup (function, cache off)', -> coffeekup.render coffeekup_template, data, cache: off
+benchmark 'CoffeeKup (string, cache off)', -> coffeekup.render coffeekup_string_template, data, cache: off
+#benchmark 'Jade (cache off)', -> jade.render jade_template, locals: data
+benchmark 'haml-js', -> haml.render haml_template, locals: data
+benchmark 'ejs (cache off)', -> ejs.render ejs_template, locals: data

--- a/benchmark.coffee
+++ b/benchmark.coffee
@@ -157,6 +157,8 @@ eco_template = '''
   </html>
 '''
 
+eco_compiled_template = eco.compile eco_template
+
 haml_template = '''
   !!! 5
   %html{lang: "en"}
@@ -194,7 +196,7 @@ benchmark 'CoffeeKup (precompiled)', -> coffeekup_compiled_template data
 benchmark 'CoffeeKup (precompiled, optimized)', -> coffeekup_optimized_template data
 benchmark 'Jade (precompiled)', -> jade_compiled_template data
 benchmark 'haml-js (precompiled)', -> haml_template_compiled data
-benchmark 'Eco', -> eco.render eco_template, data
+benchmark 'Eco (precompiled)', -> eco_compiled_template data
 
 console.log '\n'
 
@@ -202,6 +204,7 @@ benchmark 'CoffeeKup (function, cache on)', -> coffeekup.render coffeekup_templa
 benchmark 'CoffeeKup (string, cache on)', -> coffeekup.render coffeekup_string_template, data, cache: on
 #benchmark 'Jade (cache on)', -> jade.render jade_template, locals: data, cache: on, filename: 'test'
 benchmark 'ejs (cache on)', -> ejs.render ejs_template, locals: data, cache: on, filename: 'test'
+benchmark 'Eco', -> eco.render eco_template, data
 
 console.log '\n'
 

--- a/bin/coffeekup
+++ b/bin/coffeekup
@@ -1,7 +1,3 @@
-#!/usr/bin/env node
+#!/usr/bin/env coffee
 
-var path = require('path')
-var fs = require('fs')
-var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib')
-
-require(lib + '/cli').run()
+require(__dirname + '/../src/cli').run()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {"jade": "0.13.0", "eco": "1.1.0-rc-1", "ejs": "0.4.3", "haml": "0.4.2"},
   "keywords": ["template", "view", "coffeescript"],
   "bin": "./bin/coffeekup",
-  "main": "./lib/coffeekup",
+  "main": "./src/coffeekup",
   "engines": {"node": ">= 0.4.7"},
   "contributors": [
     "Luis Pedro Coelho <lpc@cmu.edu>",

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -16,6 +16,7 @@ else
   coffeekup = exports
   coffee = require 'coffee-script'
   compiler = require __dirname + '/compiler'
+  compiler.setup coffeekup
 
 coffeekup.version = '0.3.1edge'
 
@@ -91,9 +92,6 @@ coffeekup.tags = merge_elements 'regular', 'obsolete', 'void', 'obsolete_void'
 
 # Public/customizable list of elements that should be rendered self-closed.
 coffeekup.self_closing = merge_elements 'void', 'obsolete_void'
-
-if compiler?
-  compiler.setTags coffeekup.tags, coffeekup.self_closing
 
 # This is the basic material from which compiled templates will be formed.
 # It will be manipulated in its string form at the `coffeekup.compile` function

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -345,6 +345,10 @@ coffeekup.render = (template, data = {}, options = {}) ->
   data[k] = v for k, v of options
   data.cache ?= off
 
+  # Do not optimize templates if the cache is disabled, as it will slow
+  # everything down considerably.
+  if data.optimize and not data.cache then data.optimize = no
+
   if data.cache and cache[template]? then tpl = cache[template]
   else if data.cache then tpl = cache[template] = coffeekup.compile(template, data)
   else tpl = coffeekup.compile(template, data)

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -282,7 +282,6 @@ coffeekup.compile = (template, options = {}) ->
   if typeof template is 'function' then template = String(template)
   else if typeof template is 'string' and coffee?
     template = coffee.compile template, bare: yes
-    template = "(function(){#{template}})"
 
   # If an object `hardcode` is provided, insert the stringified value
   # of each variable directly in the function body. This is a less flexible but
@@ -298,6 +297,7 @@ coffeekup.compile = (template, options = {}) ->
 
   if compiler?
     return compiler.compile template, options
+  template = "function(){#{template}}"
 
   # Add a function for each tag this template references. We don't want to have
   # all hundred-odd tags wasting space in the compiled function.

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -296,7 +296,9 @@ coffeekup.compile = (template, options = {}) ->
         hardcoded_locals += "var #{k} = function(){return (#{v}).apply(data, arguments);};"
       else hardcoded_locals += "var #{k} = #{JSON.stringify v};"
 
-  if compiler?
+  # If `optimize` is set on the options hash, use uglify-js to parse the
+  # template function's code and optimize it using static analysis.
+  if options.optimize and compiler?
     return compiler.compile template, hardcoded_locals, options
 
   # Add a function for each tag this template references. We don't want to have

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -15,6 +15,7 @@ if window?
 else
   coffeekup = exports
   coffee = require 'coffee-script'
+  compiler = require __dirname + '/compiler'
 
 coffeekup.version = '0.3.1edge'
 
@@ -90,6 +91,9 @@ coffeekup.tags = merge_elements 'regular', 'obsolete', 'void', 'obsolete_void'
 
 # Public/customizable list of elements that should be rendered self-closed.
 coffeekup.self_closing = merge_elements 'void', 'obsolete_void'
+
+if compiler?
+  compiler.setTags coffeekup.tags, coffeekup.self_closing
 
 # This is the basic material from which compiled templates will be formed.
 # It will be manipulated in its string form at the `coffeekup.compile` function
@@ -280,7 +284,7 @@ coffeekup.compile = (template, options = {}) ->
   if typeof template is 'function' then template = String(template)
   else if typeof template is 'string' and coffee?
     template = coffee.compile template, bare: yes
-    template = "function(){#{template}}"
+    template = "(function(){#{template}})"
 
   # If an object `hardcode` is provided, insert the stringified value
   # of each variable directly in the function body. This is a less flexible but
@@ -293,6 +297,9 @@ coffeekup.compile = (template, options = {}) ->
         # Make sure these functions have access to `data` as `@/this`.
         hardcoded_locals += "var #{k} = function(){return (#{v}).apply(data, arguments);};"
       else hardcoded_locals += "var #{k} = #{JSON.stringify v};"
+
+  if compiler?
+    return compiler.compile template, options
 
   # Add a function for each tag this template references. We don't want to have
   # all hundred-odd tags wasting space in the compiled function.

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -296,7 +296,7 @@ coffeekup.compile = (template, options = {}) ->
       else hardcoded_locals += "var #{k} = #{JSON.stringify v};"
 
   if compiler?
-    return compiler.compile template, options
+    return compiler.compile template, hardcoded_locals, options
   template = "function(){#{template}}"
 
   # Add a function for each tag this template references. We don't want to have

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -282,6 +282,7 @@ coffeekup.compile = (template, options = {}) ->
   if typeof template is 'function' then template = String(template)
   else if typeof template is 'string' and coffee?
     template = coffee.compile template, bare: yes
+    template = "function(){#{template}}"
 
   # If an object `hardcode` is provided, insert the stringified value
   # of each variable directly in the function body. This is a less flexible but
@@ -297,7 +298,6 @@ coffeekup.compile = (template, options = {}) ->
 
   if compiler?
     return compiler.compile template, hardcoded_locals, options
-  template = "function(){#{template}}"
 
   # Add a function for each tag this template references. We don't want to have
   # all hundred-odd tags wasting space in the compiled function.

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -203,6 +203,8 @@ exports.compile = (source, hardcoded_locals, options) ->
     indent_level: 2
 
   # Main function assembly.
+  if options.locals
+    compiled = "with(data.locals){#{compiled}}"
   code = skeleton + compiled + "return __ck.buffer.join('');"
 
   return new Function 'data', code

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -101,6 +101,14 @@ exports.compile = (source, hardcoded_locals, options) ->
 
         return code.get_nodes()
 
+      else if name is 'ie'
+        [condition, contents] = args
+        code = new Code w.parent()
+        code.append "<!--[if #{condition[1]}]>"
+        code.push call_bound_func(w.walk contents)
+        code.append '<![endif]-->'
+        return code.get_nodes()
+
       else if name in coffeekup.tags or name in ['tag', 'coffeescript']
         if name is 'tag'
           name = args.shift()[1]

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -1,10 +1,10 @@
 {uglify, parser} = require 'uglify-js'
-tags = null
-self_closing = null
+coffeekup = null
 
-exports.setTags = (t, sc) ->
-  tags = t
-  self_closing = sc
+# Call this from the main script so that the compiler module can have access to
+# coffeekup exports (node does not allow circular imports).
+exports.setup = (ck) ->
+  coffeekup = ck
 
 skeleton = '''
   __ck = {
@@ -43,7 +43,7 @@ exports.compile = (source, options) ->
   ast = w.with_walkers
     call: (expr, args) ->
       tag = expr[1]
-      if tag in tags
+      if tag in coffeekup.tags
         code = "'<#{tag}"
         for arg in args
           switch arg[0]
@@ -54,13 +54,13 @@ exports.compile = (source, options) ->
                 key = attr[0]
                 value = uglify.gen_code attr[1]
                 code += " #{key}=\"' + #{value} + '\""
-        if tag in self_closing
+        if tag in coffeekup.self_closing
           code += "/>'"
         else
           code += ">'"
     
         tagopen = "text(#{code});\n"
-        if not (tag in self_closing)
+        if not (tag in coffeekup.self_closing)
           tagclose = "text('</#{tag}>');\n"
 
         funcbody = [

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -164,6 +164,12 @@ exports.compile = (source, hardcoded_locals, options) ->
                   else if value[0] is 'string'
                     code.append " #{prefix + key}=\"#{value[1]}\""
 
+                  # Functions are rendered in an executable form.
+                  else if value[0] is 'function'
+                    code.append " #{prefix + key}=\""
+                    code.push call_bound_func(value, 'this')
+                    code.append '"'
+
                   # Prefixed attribute
                   else if value[0] is 'object'
                     # `data: {icon: 'foo'}` is rendered as `data-icon="foo"`.

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -267,7 +267,7 @@ exports.compile = (source, hardcoded_locals, options) ->
               contents = escape w.walk arg
 
         if name in coffeekup.self_closing
-          code.append '/>'
+          code.append ' />'
         else
           code.append '>'
     

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -117,7 +117,7 @@ exports.compile = (source, hardcoded_locals, options) ->
               if obj_index == -1
                 args.push ['object', [['type', ['string', 'text/coffeescript']]]]
               else
-                args[obj_index].push ['type', ['string', 'text/coffeescript']]
+                args[obj_index][1].push ['type', ['string', 'text/coffeescript']]
 
         code = new Code w.parent()
         code.append "<#{name}"

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -41,10 +41,10 @@ skeleton = '''
 
 '''
 
-call_bound_func = (func, bind = 'data') ->
+call_bound_func = (func) ->
   # function(){ <func> }.call(data)
   return ['call', ['dot', func, 'call'],
-          [['name', bind]]]
+          [['name', 'data']]]
 
 # Represents compiled javascript code to be written to the template function.
 class Code
@@ -191,12 +191,10 @@ exports.compile = (source, hardcoded_locals, options) ->
             when 'function'
               # If this is a `<script>` tag, stringify the function
               if name is 'script'
-                contents = [
-                  'string'
-                  uglify.gen_code ['stat', call_bound_func(arg, 'this')],
+                func = uglify.gen_code arg,
                     beautify: true
                     indent_level: 2
-                ]
+                contents = ['string', "#{func}.call(this);"]
               # Otherwise recursively check for tag functions and inject the
               # result as a bound function call, escaping return values if necessary
               else

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -155,21 +155,24 @@ exports.compile = (source, hardcoded_locals, options) ->
                   key = attr[0]
                   value = attr[1]
 
-                  switch value[0]
-                    # If `value` is a simple string, include it in the same call to
-                    # `text` as the tag
-                    when 'string'
-                      code.append " #{prefix + key}=\"#{value[1]}\""
+                  # `true` is rendered as `selected="selected"`.
+                  if value[0] is 'name' and value[1] is 'true'
+                    code.append " #{key}=\"#{key}\""
 
-                    # Prefixed attribute
-                    when 'object'
-                      # `data: {icon: 'foo'}` is rendered as `data-icon="foo"`.
-                      render_attrs value[1], prefix + key + '-'
+                  # If `value` is a simple string, include it in the same call to
+                  # `text` as the tag
+                  else if value[0] is 'string'
+                    code.append " #{prefix + key}=\"#{value[1]}\""
 
-                    else
-                      code.append " #{prefix + key}=\""
-                      code.push value
-                      code.append '"'
+                  # Prefixed attribute
+                  else if value[0] is 'object'
+                    # `data: {icon: 'foo'}` is rendered as `data-icon="foo"`.
+                    render_attrs value[1], prefix + key + '-'
+
+                  else
+                    code.append " #{prefix + key}=\""
+                    code.push value
+                    code.append '"'
 
               render_attrs arg[1]
 

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -113,20 +113,23 @@ exports.compile = (source, hardcoded_locals, options) ->
       else if name is 'comment'
         comment = args[0]
         code = new Code w.parent()
-
         if comment[0] is 'string'
           code.append "<!--#{comment[1]}-->"
         else
           code.append '<!--'
           code.push escape comment
           code.append '-->'
-
         return code.get_nodes()
 
       else if name is 'ie'
         [condition, contents] = args
         code = new Code w.parent()
-        code.append "<!--[if #{condition[1]}]>"
+        if condition[0] is 'string'
+          code.append "<!--[if #{condition[1]}]>"
+        else
+          code.append '<!--[if '
+          code.push escape condition
+          code.append ']>'
         code.push call_bound_func(w.walk contents)
         code.append '<![endif]-->'
         return code.get_nodes()

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -115,7 +115,7 @@ exports.compile = (source, hardcoded_locals, options) ->
     indent_level: 2
 
   # Main function assembly.
-  code = hardcoded_locals + skeleton + compiled
+  code = hardcoded_locals + skeleton + "(function(){#{compiled}}).call(data);"
   code += "return __ck.buffer.join('');"
 
   return new Function 'data', code

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -14,7 +14,7 @@ skeleton = '''
   text = function(txt) {
     if (typeof txt === 'string' || txt instanceof String) {
       __ck.buffer.push(txt);
-    } else if (typeof txt === 'number' || txt instanceof Number || Array.isArray(txt)) {
+    } else if (typeof txt === 'number' || txt instanceof Number) {
       __ck.buffer.push(String(txt));
     }
   };

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -47,7 +47,10 @@ exports.compile = (source, hardcoded_locals, options) ->
         else
           throw new Error 'Invalid doctype'
 
-      else if name in coffeekup.tags
+      else if name in coffeekup.tags or name is 'tag'
+        if name is 'tag'
+          name = args.shift()[1]
+
         code = "'<#{name}"
 
         for arg in args

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -36,7 +36,7 @@ call_bound_func = (func) ->
 parse_expr = (expr) ->
   return parser.parse(expr)[1][0]
 
-exports.compile = (source, options) ->
+exports.compile = (source, hardcoded_locals, options) ->
 
   ast = parser.parse source
   w = uglify.ast_walker()
@@ -95,7 +95,8 @@ exports.compile = (source, options) ->
     beautify: true
     indent_level: 2
 
-  code = skeleton + compiled
+  # Main function assembly.
+  code = hardcoded_locals + skeleton + compiled
   code += "return __ck.buffer.join('');"
 
   return new Function 'data', code

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -274,8 +274,12 @@ exports.compile = (source, hardcoded_locals, options) ->
                 if classes.length > 0
                   code.append " class=\"#{classes.join ' '}\""
 
-              # Hardcoded string, render it as is.
+              # Hardcoded string, escape and render it.
               else
+                arg[1] = arg[1].replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;')
+                  .replace(/"/g, '&quot;')
                 contents = arg
 
             # A concatenated string e.g. `"id-" + @id`

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -14,7 +14,7 @@ skeleton = '''
   text = function(txt) {
     if (typeof txt === 'string' || txt instanceof String) {
       __ck.buffer.push(txt);
-    } else if (typeof txt === 'number' || txt instanceof Number) {
+    } else if (typeof txt === 'number' || txt instanceof Number || Array.isArray(txt)) {
       __ck.buffer.push(String(txt));
     }
   };

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -14,6 +14,12 @@ skeleton = '''
     if (typeof txt === 'string') __ck.buffer.push(txt);
     else if (typeof txt === 'number') __ck.buffer.push(String(txt));
   };
+  h = function(txt) {
+    return String(txt).replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  };
 
 '''
 
@@ -54,7 +60,6 @@ exports.compile = (source, hardcoded_locals, options) ->
                 value = uglify.gen_code attr[1]
                 code += " #{key}=\"' + #{value} + '\""
             else
-              # TODO: dynamic id and class definitions
               if arg[0] is 'string' and args.length > 1 and arg is args[0]
                 classes = []
 

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -103,13 +103,16 @@ exports.compile = (source, hardcoded_locals, options) ->
       name = expr[1]
 
       if name is 'doctype'
-        doctype = String(args[0][1])
-        if doctype of coffeekup.doctypes
-          code = new Code w.parent()
-          code.append coffeekup.doctypes[doctype]
-          return code.get_nodes()
+        code = new Code w.parent()
+        if args.length > 0
+          doctype = String(args[0][1])
+          if doctype of coffeekup.doctypes
+            code.append coffeekup.doctypes[doctype]
+          else
+            throw new Error 'Invalid doctype'
         else
-          throw new Error 'Invalid doctype'
+          code.append coffeekup.doctypes.default
+        return code.get_nodes()
 
       else if name is 'comment'
         comment = args[0]

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -118,7 +118,7 @@ exports.compile = (source, hardcoded_locals, options) ->
           code.append "<!--#{comment[1]}-->"
         else
           code.append '<!--'
-          code.push comment
+          code.push escape comment
           code.append '-->'
 
         return code.get_nodes()

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -42,9 +42,17 @@ exports.compile = (source, hardcoded_locals, options) ->
   w = uglify.ast_walker()
   ast = w.with_walkers
     call: (expr, args) ->
-      tag = expr[1]
-      if tag in coffeekup.tags
-        code = "'<#{tag}"
+      name = expr[1]
+
+      if name is 'doctype'
+        if args.length is 1 and String(args[0][1]) of coffeekup.doctypes
+          return ['call', ['name', 'text'],
+                  [['string', coffeekup.doctypes[String(args[0][1])]]]]
+        else
+          throw new Error 'Invalid doctype'
+
+      else if name in coffeekup.tags
+        code = "'<#{name}"
 
         for arg in args
           switch arg[0]
@@ -73,14 +81,14 @@ exports.compile = (source, hardcoded_locals, options) ->
               else
                 contents = arg
 
-        if tag in coffeekup.self_closing
+        if name in coffeekup.self_closing
           code += "/>'"
         else
           code += ">'"
     
         tagopen = "text(#{code});\n"
-        if not (tag in coffeekup.self_closing)
-          tagclose = "text('</#{tag}>');\n"
+        if not (name in coffeekup.self_closing)
+          tagclose = "text('</#{name}>');\n"
 
         funcbody = [
           parse_expr tagopen

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -162,7 +162,7 @@ exports.compile = (source, hardcoded_locals, options) ->
               # only supports simple string values: if you need to determine
               # this tag's id or class dynamically, pass the value in an object
               # e.g. `div id: "id", class: "class1 class2"`
-              if arg[0] is 'string' and args.length > 1 and arg is args[0]
+              if arg[0] is 'string' and args.length > 1 and arg is args[0] and name != 'script'
                 classes = []
 
                 for i in arg[1].split '.'

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -12,6 +12,7 @@ skeleton = '''
   };
   text = function(txt) {
     if (typeof txt === 'string') __ck.buffer.push(txt);
+    else if (typeof txt === 'number') __ck.buffer.push(String(txt));
   };
 
 '''

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -45,15 +45,34 @@ exports.compile = (source, hardcoded_locals, options) ->
       tag = expr[1]
       if tag in coffeekup.tags
         code = "'<#{tag}"
+
         for arg in args
           switch arg[0]
             when 'function'
-              contents = arg
+              contents = call_bound_func(w.walk arg)
             when 'object'
               for attr in arg[1]
                 key = attr[0]
                 value = uglify.gen_code attr[1]
                 code += " #{key}=\"' + #{value} + '\""
+            else
+              # TODO: dynamic id and class definitions
+              if arg[0] is 'string' and args.length > 1 and arg is args[0]
+                classes = []
+
+                for i in arg[1].split '.'
+                  if '#' in i
+                    id = i.replace '#', ''
+                  else
+                    classes.push i unless i is ''
+
+                code += " id=\"#{id}\"" if id
+
+                if classes.length > 0
+                  code += " class=\"#{classes.join ' '}\""
+              else
+                contents = arg
+
         if tag in coffeekup.self_closing
           code += "/>'"
         else
@@ -73,7 +92,7 @@ exports.compile = (source, hardcoded_locals, options) ->
                 'name'
                 'text'
               ]
-              [call_bound_func(w.walk contents)]
+              [contents]
             ]
           ]
         ]

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -38,7 +38,7 @@ parse_expr = (expr) ->
 
 exports.compile = (source, hardcoded_locals, options) ->
 
-  ast = parser.parse source
+  ast = parser.parse "(#{source}).call(data);"
   w = uglify.ast_walker()
   ast = w.with_walkers
     call: (expr, args) ->
@@ -121,7 +121,7 @@ exports.compile = (source, hardcoded_locals, options) ->
     indent_level: 2
 
   # Main function assembly.
-  code = hardcoded_locals + skeleton + "(function(){#{compiled}}).call(data);"
+  code = hardcoded_locals + skeleton + compiled
   code += "return __ck.buffer.join('');"
 
   return new Function 'data', code

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -9,13 +9,13 @@ exports.setup = (ck) ->
 
 skeleton = '''
   __ck = {
-    buffer: []
+    buffer: ''
   };
   text = function(txt) {
     if (typeof txt === 'string' || txt instanceof String) {
-      __ck.buffer.push(txt);
+      __ck.buffer += txt;
     } else if (typeof txt === 'number' || txt instanceof Number) {
-      __ck.buffer.push(String(txt));
+      __ck.buffer += String(txt);
     }
   };
   h = function(txt) {
@@ -31,12 +31,13 @@ skeleton = '''
     return escaped;
   };
   yield = function(f) {
-    var temp_buffer = [];
+    var temp_buffer = '';
     var old_buffer = __ck.buffer;
     __ck.buffer = temp_buffer;
     f();
+    temp_buffer = __ck.buffer;
     __ck.buffer = old_buffer;
-    return temp_buffer.join('');
+    return temp_buffer;
   };
 
 '''
@@ -333,7 +334,7 @@ exports.compile = (source, hardcoded_locals, options) ->
   # Main function assembly.
   if options.locals
     compiled = "with(data.locals){#{compiled}}"
-  code = skeleton + compiled + "return __ck.buffer.join('');"
+  code = skeleton + compiled + "return __ck.buffer;"
 
   return new Function 'data', code
 

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -90,9 +90,9 @@ exports.compile = (source, hardcoded_locals, options) ->
         if not (name in coffeekup.self_closing)
           tagclose = "text('</#{name}>');\n"
 
-        funcbody = [
-          parse_expr tagopen
-          [
+        funcbody = [parse_expr tagopen]
+        if contents?
+          funcbody.push [
             'stat'
             [
               'call'
@@ -103,7 +103,6 @@ exports.compile = (source, hardcoded_locals, options) ->
               [contents]
             ]
           ]
-        ]
         if tagclose?
           funcbody.push parse_expr tagclose
 

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -8,17 +8,17 @@ exports.setup = (ck) ->
   coffeekup = ck
 
 skeleton = '''
-  __ck = {
+  var __ck = {
     buffer: ''
   };
-  text = function(txt) {
+  var text = function(txt) {
     if (typeof txt === 'string' || txt instanceof String) {
       __ck.buffer += txt;
     } else if (typeof txt === 'number' || txt instanceof Number) {
       __ck.buffer += String(txt);
     }
   };
-  h = function(txt) {
+  var h = function(txt) {
     var escaped;
     if (typeof txt === 'string' || txt instanceof String) {
       escaped = txt.replace(/&/g, '&amp;')
@@ -30,7 +30,7 @@ skeleton = '''
     }
     return escaped;
   };
-  yield = function(f) {
+  var yield = function(f) {
     var temp_buffer = '';
     var old_buffer = __ck.buffer;
     __ck.buffer = temp_buffer;

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -150,20 +150,28 @@ exports.compile = (source, hardcoded_locals, options) ->
                 contents = call_bound_func(w.walk arg)
 
             when 'object'
-              for attr in arg[1]
-                key = attr[0]
-                value = attr[1]
+              render_attrs = (obj, prefix = '') ->
+                for attr in obj
+                  key = attr[0]
+                  value = attr[1]
 
-                # If `value` is a simple string, include it in the same call to
-                # `text` as the tag
-                if value[0] is 'string'
-                  code.append " #{key}=\"#{value[1]}\""
+                  switch value[0]
+                    # If `value` is a simple string, include it in the same call to
+                    # `text` as the tag
+                    when 'string'
+                      code.append " #{prefix + key}=\"#{value[1]}\""
 
-                # Otherwise put it in a separate tag
-                else
-                  code.append " #{key}=\""
-                  code.push value
-                  code.append '"'
+                    # Prefixed attribute
+                    when 'object'
+                      # `data: {icon: 'foo'}` is rendered as `data-icon="foo"`.
+                      render_attrs value[1], prefix + key + '-'
+
+                    else
+                      code.append " #{prefix + key}=\""
+                      code.push value
+                      code.append '"'
+
+              render_attrs arg[1]
 
             else
               # id class string: `"#id.class1.class2"`. Note that this compiler

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -99,6 +99,12 @@ exports.compile = (source, hardcoded_locals, options) ->
         if tagclose?
           funcbody.push parse_expr tagclose
 
+        if w.parent()[0] is 'stat'
+          return [
+            'splice'
+            funcbody
+          ]
+
         return call_bound_func([
           'function'
           null # Anonymous function

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -240,11 +240,10 @@ exports.compile = (source, hardcoded_locals, options) ->
                   else if value[0] is 'string'
                     code.append " #{prefix + key}=\"#{value[1]}\""
 
-                  # Functions are rendered in an executable form.
+                  # Functions are prerendered as text
                   else if value[0] is 'function'
-                    code.append " #{prefix + key}=\""
-                    code.push escape call_bound_func(value, 'this')
-                    code.append '"'
+                    func = uglify.gen_code(value).replace(/"/g, '&quot;')
+                    code.append " #{prefix + key}=\"#{func}.call(this);\""
 
                   # Prefixed attribute
                   else if value[0] is 'object'

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -1,0 +1,102 @@
+{uglify, parser} = require 'uglify-js'
+tags = null
+self_closing = null
+
+exports.setTags = (t, sc) ->
+  tags = t
+  self_closing = sc
+
+skeleton = '''
+  __ck = {
+    buffer: []
+  };
+  text = function(txt) {
+    if (typeof txt === 'string') __ck.buffer.push(txt);
+  };
+
+'''
+
+call_bound_func = (func) ->
+  return [
+    'call'
+    [
+      'dot'
+      func
+      'call'
+    ]
+    [
+      [
+        'name'
+        'data'
+      ]
+    ]
+  ]
+
+# Returns the first ast node for the given expression
+parse_expr = (expr) ->
+  return parser.parse(expr)[1][0]
+
+exports.compile = (source, options) ->
+
+  ast = parser.parse source
+  w = uglify.ast_walker()
+  ast = w.with_walkers
+    call: (expr, args) ->
+      tag = expr[1]
+      if tag in tags
+        code = "'<#{tag}"
+        for arg in args
+          switch arg[0]
+            when 'function'
+              contents = arg
+            when 'object'
+              for attr in arg[1]
+                key = attr[0]
+                value = uglify.gen_code attr[1]
+                code += " #{key}=\"' + #{value} + '\""
+        if tag in self_closing
+          code += "/>'"
+        else
+          code += ">'"
+    
+        tagopen = "text(#{code});\n"
+        if not (tag in self_closing)
+          tagclose = "text('</#{tag}>');\n"
+
+        funcbody = [
+          parse_expr tagopen
+          [
+            'stat'
+            [
+              'call'
+              [
+                'name'
+                'text'
+              ]
+              [call_bound_func(w.walk contents)]
+            ]
+          ]
+        ]
+        if tagclose?
+          funcbody.push parse_expr tagclose
+
+        return call_bound_func([
+          'function'
+          null # Anonymous function
+          [] # Takes no arguments
+          funcbody
+        ])
+
+      return [this[0], w.walk(expr), uglify.MAP(args, w.walk)]
+    , ->
+      return w.walk ast
+
+  compiled = uglify.gen_code ast,
+    beautify: true
+    indent_level: 2
+
+  code = skeleton + compiled
+  code += "return __ck.buffer.join('');"
+
+  return new Function 'data', code
+

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -20,6 +20,14 @@ skeleton = '''
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
   };
+  yield = function(f) {
+    var temp_buffer = [];
+    var old_buffer = __ck.buffer;
+    __ck.buffer = temp_buffer;
+    f();
+    __ck.buffer = old_buffer;
+    return temp_buffer.join('');
+  };
 
 '''
 
@@ -205,7 +213,7 @@ exports.compile = (source, hardcoded_locals, options) ->
               # that the `text()` function in the template skeleton will only
               # output strings and numbers.
               else
-                contents = arg
+                contents = w.walk arg
 
         if name in coffeekup.self_closing
           code.append '/>'

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -202,7 +202,7 @@ exports.compile = (source, hardcoded_locals, options) ->
 
             when 'string'
               # id class string: `"#id.class1.class2"`. Note that this compiler
-              # only supports simple string values: if you need to determine
+              # only supports hardcoded string values: if you need to determine
               # this tag's id or class dynamically, pass the value in an object
               # e.g. `div id: @getId(), class: getClasses()`
               if args.length > 1 and arg is args[0]
@@ -219,13 +219,15 @@ exports.compile = (source, hardcoded_locals, options) ->
                 if classes.length > 0
                   code.append " class=\"#{classes.join ' '}\""
 
-              # Simple string, render it as is.
+              # Hardcoded string, render it as is.
               else
                 code.append arg[1]
 
             # A concatenated string e.g. `"id-" + @id`
             when 'binary'
 
+              # Traverse the ast nodes, selectively escaping anything other
+              # than hardcoded strings and calls to `yield`.
               escape_all = (node) ->
                 switch node[0]
                   when 'binary'
@@ -247,7 +249,7 @@ exports.compile = (source, hardcoded_locals, options) ->
             # that the `text()` function in the template skeleton will only
             # output strings and numbers.
             else
-              contents = w.walk arg
+              contents = escape w.walk arg
 
         if name in coffeekup.self_closing
           code.append '/>'

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -38,7 +38,7 @@ parse_expr = (expr) ->
 
 exports.compile = (source, hardcoded_locals, options) ->
 
-  ast = parser.parse "(#{source}).call(data);"
+  ast = parser.parse hardcoded_locals + "(#{source}).call(data);"
   w = uglify.ast_walker()
   ast = w.with_walkers
     call: (expr, args) ->
@@ -121,8 +121,7 @@ exports.compile = (source, hardcoded_locals, options) ->
     indent_level: 2
 
   # Main function assembly.
-  code = hardcoded_locals + skeleton + compiled
-  code += "return __ck.buffer.join('');"
+  code = skeleton + compiled + "return __ck.buffer.join('');"
 
   return new Function 'data', code
 

--- a/test.coffee
+++ b/test.coffee
@@ -142,7 +142,7 @@ tests =
       
   'Attribute values':
     template: "br vrai: yes, faux: no, undef: @foo, nil: null, str: 'str', num: 42, arr: [1, 2, 3], obj: {foo: 'bar'}, func: ->"
-    expected: '<br vrai="vrai" str="str" num="42" arr="1,2,3" obj-foo="bar" func="(function () {}).call(this);" />'
+    expected: '<br vrai="vrai" str="str" num="42" arr="1,2,3" obj-foo="bar" func="(function(){}).call(this);" />'
     
   'IE conditionals':
     template: """

--- a/test.coffee
+++ b/test.coffee
@@ -152,18 +152,19 @@ tests =
           ie 'gte IE8', ->
             link href: 'ie.css', rel: 'stylesheet'
     """
-    expected: '''
-      <html>
-        <head>
-          <title>test</title>
-          <!--[if gte IE8]>
-            <link href="ie.css" rel="stylesheet" />
-          <![endif]-->
-        </head>
-      </html>
-      
-    '''
-    params: {format: yes}
+    expected: '<html><head><title>test</title><!--[if gte IE8]><link href="ie.css" rel="stylesheet" /><![endif]--></head></html>'
+    #expected: '''
+    #  <html>
+    #    <head>
+    #      <title>test</title>
+    #      <!--[if gte IE8]>
+    #        <link href="ie.css" rel="stylesheet" />
+    #      <![endif]-->
+    #    </head>
+    #  </html>
+    #  
+    #'''
+    #params: {format: yes}
     
   'yield':
     template: "p \"This text could use \#{yield -> strong -> a href: '/', 'a link'}.\""

--- a/test.coffee
+++ b/test.coffee
@@ -114,9 +114,11 @@ tests =
     expected: "<h1>&lt;script&gt;alert('&quot;pwned&quot; by c&amp;a &amp;copy;')&lt;/script&gt;</h1>"
 
   'Autoescaping':
-    template: "h1 \"<script>alert('\\\"pwned\\\" by c&a &copy;')</script>\""
+    template: "h1 @script"
     expected: "<h1>&lt;script&gt;alert('&quot;pwned&quot; by c&amp;a &amp;copy;')&lt;/script&gt;</h1>"
-    params: {autoescape: yes}
+    params:
+      autoescape: yes
+      script: "<script>alert('\"pwned\" by c&a &copy;')</script>"
 
   'ID/class shortcut (combo)':
     template: "div '#myid.myclass1.myclass2', 'foo'"

--- a/test.coffee
+++ b/test.coffee
@@ -1,3 +1,5 @@
+#!/usr/bin/env coffee
+
 tests =
   'Literal text':
     template: "text 'Just text'"
@@ -219,3 +221,5 @@ render = ck.render
       print t.template + "\n"
       printc 'green', t.expected + "\n"
       printc 'redder', t.result.stack + "\n\n"
+
+@run()

--- a/test_optimized.coffee
+++ b/test_optimized.coffee
@@ -111,11 +111,10 @@ tests =
     expected: "<h1>&lt;script&gt;alert('&quot;pwned&quot; by c&amp;a &amp;copy;')&lt;/script&gt;</h1>"
 
   'Autoescaping':
-    template: "h1 @script"
+    template: "h1 \"<script>alert('\\\"pwned\\\" by c&a &copy;')</script>\""
     expected: "<h1>&lt;script&gt;alert('&quot;pwned&quot; by c&amp;a &amp;copy;')&lt;/script&gt;</h1>"
     params:
       autoescape: yes
-      script: "<script>alert('\"pwned\" by c&a &copy;')</script>"
 
   'ID/class shortcut (combo)':
     template: "div '#myid.myclass1.myclass2', 'foo'"
@@ -183,8 +182,10 @@ render = ck.render
       if not test.params?
         test.params =
           optimize: true
+          cache: on
       else
         test.params.optimize = true
+        test.params.cache = true
       test.original_params = JSON.stringify test.params
 
       if test.run

--- a/test_optimized.coffee
+++ b/test_optimized.coffee
@@ -137,7 +137,7 @@ tests =
     expected: '<img id="myid" class="myclass" src="/pic.png" />'
       
   'Attribute values':
-    template: "br vrai: yes, faux: no, undef: @foo, nil: null, str: 'str', num: 42, arr: [1, 2, 3], obj: {foo: 'bar'}, func: ->"
+    template: "br vrai: yes, faux: no, undef: @foo, nil: null, str: 'str', num: 42, arr: [1, 2, 3].join(','), obj: {foo: 'bar'}, func: ->"
     expected: '<br vrai="vrai" str="str" num="42" arr="1,2,3" obj-foo="bar" func="(function(){}).call(this);" />'
     
   'IE conditionals':


### PR DESCRIPTION
I have been experimenting with optimizing coffeekup templates using [UglifyJS](http://github.com/mishoo/UglifyJS) to analyze the template source and prerender the html. The idea is to turn this:

``` javascript
function() {
  //
  // Lots of boilerplate code...
  //
  html(function() {
    head(function() {
      return title(this.title);
    });
    return body(function() {
      h1(this.title);
      return p('Super fast templates');
    });
  });}).call(data);return __ck.buffer.join('');
}
```

into this:

``` javascript
function() {
  //
  // Much less boilerplate
  //
  ((function() {
    text("<!DOCTYPE html>");
    text("<html>");
    text(function() {
      text("<head>");
      text(function() {
        return function() {
          text("<title>");
          text(this.title);
          text("</title>");
        }.call(data);
      }.call(data));
      text("</head>");
      return function() {
        text("<body>");
        text(function() {
          text("<h1>");
          text(this.title);
          text("</h1>");
          return function() {
            text("<p>");
            text("Super fast templates");
            text("</p>");
          }.call(data);
        }.call(data));
        text("</body>");
      }.call(data);
    }.call(data));
    text("</html>");
  })).call(data);return __ck.buffer;
}
```

The advantages of this approach are shorter template functions (unless the template is very long) thanks to reduced boilerplate, and faster execution owing to much of the work being done at compile time. A further performance improvement is achieved by using string concatenation rather than array join to build the output. Here are my benchmark results, running a compiled template 5000 times on node:

```
CoffeeKup (precompiled): 263 ms
CoffeeKup (precompiled, optimized): 24 ms
Jade (precompiled): 530 ms
haml-js (precompiled): 89 ms
Eco: 92 ms
```

See here for browser rendering performance: http://jsperf.com/coffeekup-optimized/2

As far as I can tell, these optimizations give a 10x performance boost on node, a 30x boost in Chrome and a more modest 3x improvement in Firefox.
## Usage

``` coffeescript
template = coffeekup.compile 'h1 @title', optimize: yes
template(title: 'Super fast template')
# '<h1>Super fast template</h1>'
```
## Caveats

As this compiler uses static analysis to optimize your templates, too much complex logic may cause it to fall over. But templates should be logic-free so that shouldn't be a problem, right?

I have aimed for API compatibility with regular coffeekup, but there are a few differences to be aware of:
- The `coffeescript` helper function does not add `"text/coffeescript"` to the `<script>` tag. I could implement this, but it doesn't strike me as very useful.
- Output formatting is not implemented (yet). You get a single line of html.
- Arrays are not rendered directly in the template output. Join them into a string before passing them to the compiled template function.
- You can't set up a hash of options and then pass it to the tag function, e.g.

``` coffeescript
attrs =
  name: 'email'
  type: 'text'
input attrs
```

Do this instead:

``` coffeescript
input
  name: 'email'
  type: 'text'
```

I have made some minor modifications to the test suite to account for the above.
