### PR TITLE
Adding more output options

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -49,7 +49,9 @@ usage = '''
 '''
 
 switches = [
-  ['--js', 'compile template to js function']
+  ['-j', '--js', 'compile template to js function (template + embedded renderer)']
+  ['-b', '--bare', 'use with -j to compile template to js (template only)' ]
+  ['-c', '--core', 'use with -j to compile renderer to js (renderer only)' ]
   ['-n', '--namespace [name]', 'global object holding the templates (default: "templates")']
   ['-w', '--watch', 'watch templates for changes, and recompile']
   ['-o', '--output [dir]', 'set the directory for compiled html']

--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -302,24 +302,28 @@ coffeekup.compile = (template, options = {}) ->
   for t in coffeekup.tags
     if template.indexOf(t) > -1 or hardcoded_locals.indexOf(t) > -1
       tags_used.push t
-      
+  
   tag_functions += "var #{tags_used.join ','};"
   for t in tags_used
     tag_functions += "#{t} = function(){return __ck.tag('#{t}', arguments);};"
 
-  # Main function assembly.
-  code = tag_functions + hardcoded_locals + skeleton
+  # # Main function assembly.
+  code = ""
 
-  code += "__ck.doctypes = #{JSON.stringify coffeekup.doctypes};"
-  code += "__ck.coffeescript_helpers = #{JSON.stringify coffeescript_helpers};"
-  code += "__ck.self_closing = #{JSON.stringify coffeekup.self_closing};"
-
-  # If `locals` is set, wrap the template inside a `with` block. This is the
-  # most flexible but slower approach to specifying local variables.
-  code += 'with(data.locals){' if options.locals
-  code += "(#{template}).call(data);"
-  code += '}' if options.locals
-  code += "return __ck.buffer.join('');"
+  # If bare is used, the main mechanism is stripped from template
+  unless options.bare && !options.core
+    code += tag_functions + hardcoded_locals + skeleton
+    code += "__ck.doctypes = #{JSON.stringify coffeekup.doctypes};"
+    code += "__ck.coffeescript_helpers = #{JSON.stringify coffeescript_helpers};"
+    code += "__ck.self_closing = #{JSON.stringify coffeekup.self_closing};"
+  
+  unless options.core && !options.bare
+    # If `locals` is set, wrap the template inside a `with` block. This is the
+    # most flexible but slower approach to specifying local variables.
+    code += 'with(data.locals){' if options.locals
+    code += "(#{template}).call(data);"
+    code += '}' if options.locals
+    code += "return __ck.buffer.join('');"
   
   new Function('data', code)
 


### PR DESCRIPTION
When you need to export more than one tempalte to js, you probably want to separate the renderer logic from the template itself instead of embedding it in every template, making your output file bigger.

This patch adds two news options to the cli:

```
-  ['--js', 'compile template to js function']
+  ['-j', '--js', 'compile template to js function (template + embedded renderer)']
+  ['-b', '--bare', 'use with -j to compile template to js (template only)' ]
+  ['-c', '--core', 'use with -j to compile renderer to js (renderer only)' ]
```
