### PR TITLE
Added AMD support.

### DIFF
--- a/src/coffeekup.coffee
+++ b/src/coffeekup.coffee
@@ -10,8 +10,20 @@
 # stiff.
 
 if window?
-  coffeekup = window.CoffeeKup = {}
-  coffee = if CoffeeScript? then CoffeeScript else null
+  # coffee is explicitly defined in this scope otherwise coffeescript's lexical 
+  # scoping would stop us from accessing it in the AMD define() callback.
+  # coffeekup is also explicit here as AMD load needs it initialized as normal.
+  coffee = null
+  coffeekup = {}
+
+  # Register this module using AMD if available.
+  if typeof define is 'function' and define.amd
+    define ['coffee-script'], (CoffeeScript) ->
+      coffee = CoffeeScript
+      return coffeekup
+  else
+    window.CoffeeKup = coffeekup
+    coffee = CoffeeScript if CoffeeScript?
 else
   coffeekup = exports
   coffee = require 'coffee-script'


### PR DESCRIPTION
Hi,

This patch enabled AMD loading of CoffeeKup in the browser. I've tested these changes using RequireJS and standard script tag loading in the browser.

I set the dependency on CoffeeScript to use the tag "coffee-script", since the coffee-script browser distributable js file is named this way.

It's probably best not to land this patch until/unless jashkenas/coffee-script#1826 is merged. Either that or explain to people that they'll need to write a AMD shim for CoffeeScript in order for CoffeeKup AMD loading to work properly.

Cheers!
