### PR TITLE
Added docpad to the tools listing as it supports CoffeeKup

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 - [cupcake](https://github.com/twilson63/cupcake) - Express app generator with CoffeeKup support.
 
-- [docpad](https://github.com/balupton/docpad) - Static site generator and cms with coffeekup support.
+- [docpad](https://github.com/balupton/docpad) - Static site generator and CMS with CoffeeKup support.
 
 ## Related projects
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 - [cupcake](https://github.com/twilson63/cupcake) - Express app generator with CoffeeKup support.
 
+- [docpad](https://github.com/balupton/docpad) - Static site generator and cms with coffeekup support.
+
 ## Related projects
 
 - [ck](https://github.com/aeosynth/ck) - "a smaller, faster coffeekup": Alternative, barebones implementation.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 - [cupcake](https://github.com/twilson63/cupcake) - Express app generator with CoffeeKup support.
 
-- [docpad](https://github.com/balupton/docpad) - Static site generator and CMS with CoffeeKup support.
+- [docpad](https://github.com/balupton/docpad) - Static site generator / CMS with CoffeeKup support.
 
 ## Related projects
 


### PR DESCRIPTION
[DocPad](https://github.com/balupton/docpad) is a static site generator and CMS which supports CoffeeKup. Personally, CoffeeKup is my favourite markup to use it with :-)

Wrote this pull request as perhaps it'll help other people get started with coffeekup too :-)
